### PR TITLE
Remove unused exit state from contact page

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -17,7 +17,6 @@ const Footer = lazy(() => import("../../components/sections/Footer"))
 const ContactPage = () => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
-  const [isExiting, setIsExiting] = useState(false)
   const { scrollYProgress } = useScroll()
   const scaleX = useSpring(scrollYProgress, {
     stiffness: 100,
@@ -66,7 +65,6 @@ const ContactPage = () => {
 
   const handleExit = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
     e.preventDefault()
-    setIsExiting(true)
     setTimeout(() => {
       router.push(href)
     }, 500) // Correspond à la durée de l'animation de sortie


### PR DESCRIPTION
## Summary
- remove unused `isExiting` state from the contact page

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, react/display-name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840a6fa9118832b8fa76304bc48ed0d