### PR TITLE
Add display names for memoized components

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -218,6 +218,7 @@ const InputField = React.memo(({ type, name, placeholder, required }) => (
     />
   </motion.div>
 ))
+InputField.displayName = "InputField"
 
 const TextareaField = React.memo(({ name, placeholder, required }) => (
   <motion.div className="relative overflow-hidden rounded-lg" whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
@@ -236,6 +237,7 @@ const TextareaField = React.memo(({ name, placeholder, required }) => (
     />
   </motion.div>
 ))
+TextareaField.displayName = "TextareaField"
 
 const BackgroundAnimation = React.memo(() => (
   <motion.div
@@ -257,6 +259,7 @@ const BackgroundAnimation = React.memo(() => (
     }}
   />
 ))
+BackgroundAnimation.displayName = "BackgroundAnimation"
 
 export default ContactPage
 


### PR DESCRIPTION
## Summary
- set `displayName` on memoized components on the contact page

## Testing
- `npm run lint` *(fails: isExiting assigned but never used, react/no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840a6fc3090832ba2da5b02d043b27e