### PR TITLE
Fix ref initialization for ProjectsSection

### DIFF
--- a/components/sections/ProjectsSection.tsx
+++ b/components/sections/ProjectsSection.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import React, { useRef } from 'react';
+import React, { useRef, createRef } from 'react';
 import { Parallax } from 'react-scroll-parallax';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import SectionTitle from '../ui/SectionTitle';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 const projets = [
@@ -18,7 +17,9 @@ const projets = [
 ];
 
 const ProjectsSection = () => {
-  const refsProjets = Array(6).fill().map(() => useRef(null));
+  const refsProjets = useRef(
+    Array.from({ length: 6 }, () => createRef<HTMLDivElement>())
+  );
   const router = useRouter();
 
   const handleProjectClick = (projectId) => {
@@ -45,7 +46,7 @@ const ProjectsSection = () => {
           {projets.map((projet, index) => (
             <motion.div
               key={projet.id}
-              ref={refsProjets[index]}
+              ref={refsProjets.current[index]}
               className="flex flex-col md:flex-row items-center gap-8 sm:gap-12 md:gap-16"
               initial="masque"
               whileInView="visible"


### PR DESCRIPTION
## Summary
- initialize project refs using a single `useRef` array
- remove unused imports

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840a707dd44832b80a6cf5282e53931